### PR TITLE
fix: improve flaresolverr compatibility for cookies

### DIFF
--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -61,13 +61,18 @@ def read_item(request: LinkRequest, sb: SeleniumDep) -> LinkResponse:
         save_screenshot(sb)
         raise HTTPException(status_code=500, detail="Could not bypass challenge")
 
+    cookies = sb.get_cookies()
+    for cookie in cookies:
+        if 'expiry' in cookie:
+            cookie['expires'] = cookie['expiry']
+
     return LinkResponse(
         message="Success",
         solution=Solution(
             userAgent=sb.get_user_agent(),
             url=sb.get_current_url(),
             status=200,
-            cookies=sb.get_cookies(),
+            cookies=cookies,
             headers={},
             response=str(sb.get_beautiful_soup()),
         ),


### PR DESCRIPTION
For cookies, the `expiry` field returned by the API doesn't match the `expires` that is returned by FlareSolverr.
Since this project aims to be a drop-in replacement for FlareSolverr, I have added it to the response object, but without removing the current `expiry` field to ensure backwards compatibility.
Let me know if you would prefer to remove the `expiry` field completely instead of keeping both `expiry` and `expires`.

The `session` and `size` fields are also missing, but as I have 0 experience with both Python and SeleniumBase, I'm not sure where to find them, if they can be found at all. And, for my use-case anyway, only the missing `expires` field was breaking functionality (I'm using FlareSolverrSharp, which deserializes the response into a class expecting `expires` in the cookies).

