### PR TITLE
Proxy server mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,18 +7,29 @@ from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
 
 from src.consts import LOG_LEVEL, VERSION
-from src.endpoints import router
+from src.endpoints import router as api_router
+from src.proxy_endpoints import router as proxy_router
+import argparse
 from src.middlewares import LogRequest
 from src.utils import logger
 
 logger.info("Using version %s", VERSION)
 
-app = FastAPI(debug=LOG_LEVEL == logging.DEBUG, log_level=LOG_LEVEL)
-app.add_middleware(GZipMiddleware)
-app.add_middleware(LogRequest)
-
-app.include_router(router=router)
-
+def create_app(proxy_mode: bool = False):
+    application = FastAPI(debug=LOG_LEVEL == logging.DEBUG, log_level=LOG_LEVEL)
+    application.add_middleware(GZipMiddleware)
+    application.add_middleware(LogRequest)
+    if proxy_mode:
+        application.include_router(proxy_router)
+        logger.info("Proxy mode enabled.")
+    else:
+        application.include_router(api_router)
+        logger.info("API mode enabled.")
+    return application
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Byparr Server")
+    parser.add_argument("--proxy-mode", action="store_true", help="Run as HTTP proxy server only.")
+    args = parser.parse_args()
+    app = create_app(proxy_mode=args.proxy_mode)
     uvicorn.run(app, host="0.0.0.0", port=8191, log_level=LOG_LEVEL)  # noqa: S104

--- a/src/proxy_endpoints.py
+++ b/src/proxy_endpoints.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import PlainTextResponse, HTMLResponse
+import logging
+from src.utils import get_sb, logger, save_screenshot
+from src.consts import CHALLENGE_TITLES
+from fastapi import HTTPException
+from sbase import BaseCase
+
+router = APIRouter()
+proxy_logger = logging.getLogger("proxy")
+
+async def log_proxy_request(request: Request):
+    proxy_logger.info(f"Proxying {request.method} {request.url}")
+
+@router.api_route("/{full_path:path}", methods=["GET"])
+async def proxy_handler(full_path: str, request: Request):
+    await log_proxy_request(request)
+
+    # Only support GET for proxy mode (as /v1 does)
+    # Extract the full URL from the incoming request (including scheme)
+    # FastAPI's request.url._url gives the full proxy-style URL (e.g., http:// or https://)
+    url = request.url._url
+    # Remove the proxy server's own host/port, so we get the target URL
+    # Example: url = 'https://www.bikemn.org/get-involved/clubs-teams/'
+    # This works for curl and most HTTP clients using --proxy
+    # If the scheme is missing, fallback to http
+    if not url.startswith("http://") and not url.startswith("https://"):
+        url = "http://" + url.lstrip("/")
+
+    # Use the same Selenium logic as /v1
+    try:
+        sb_gen = get_sb(proxy=None)
+        sb = next(sb_gen)
+        sb.uc_open_with_reconnect(url)
+        logger.debug(f"Got webpage: {url}")
+        source_bs = sb.get_beautiful_soup()
+        title_tag = source_bs.title
+        if title_tag and title_tag.string in CHALLENGE_TITLES:
+            logger.debug("Challenge detected")
+            sb.uc_gui_click_captcha()
+            logger.info("Clicked captcha")
+        if sb.get_title() in CHALLENGE_TITLES:
+            save_screenshot(sb)
+            return Response("Could not bypass challenge", status_code=500)
+        cookies = sb.get_cookies()
+        # Compose Set-Cookie headers
+        response_headers = {}
+        set_cookie_headers = []
+        for cookie in cookies:
+            cookie_str = f"{cookie['name']}={cookie['value']}"
+            if 'expiry' in cookie:
+                cookie_str += f"; Expires={cookie['expiry']}"
+            if cookie.get('path'):
+                cookie_str += f"; Path={cookie['path']}"
+            set_cookie_headers.append(("set-cookie", cookie_str))
+        # Compose response
+        html = str(sb.get_beautiful_soup())
+        # Use FastAPI's HTMLResponse to set multiple Set-Cookie headers
+        resp = HTMLResponse(
+            content=html,
+            status_code=200,
+            headers={h: v for h, v in set_cookie_headers},
+        )
+        # Actually set all Set-Cookie headers
+        for k, v in set_cookie_headers:
+            resp.headers.append(k, v)
+        return resp
+    except Exception as e:
+        logger.error(f"Proxy error: {e}")
+        return Response("Internal server error", status_code=500)


### PR DESCRIPTION
fixes #161 

## Description

This is a draft of the suggested proxy mode.  It only supports HTTP requests.  HTTPS proxy support must be implemented at the TCP level and is not possible with FastAPI.

Please let me know what you think of the approach and scope of support and I can clean it up with better error handling and refactor the common bits.

## Usage

```
# Server
uv run main.py --proxy

# client
curl --proxy http://localhost:8191 http://example.com
```