### PR TITLE
fix: handle zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV GITHUB_BUILD=${GITHUB_BUILD}\
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests xauth xvfb scrot curl chromium chromium-driver ca-certificates
+    apt-get install -y --no-install-recommends --no-install-suggests xauth xvfb scrot curl chromium chromium-driver ca-certificates tini
 
 ADD https://astral.sh/uv/install.sh install.sh
 RUN sh install.sh && uv --version
@@ -44,4 +44,4 @@ RUN ./test.sh
 FROM app
 EXPOSE 8191
 HEALTHCHECK --interval=15m --timeout=30s --start-period=5s --retries=3 CMD [ "curl", "http://localhost:8191/health" ]
-ENTRYPOINT ["uv", "run", "main.py"]
+ENTRYPOINT ["/usr/bin/tini", "--", "uv", "run", "main.py"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -27,14 +27,19 @@ def get_sb(
             detail="SOCKS5 proxy with authentication is not supported. Check README for more info.",
         )
 
-    with SB(
+    sb_ctx = SB(
         uc=True,
         headless=USE_HEADLESS,
         locale_code="en",
         ad_block=True,
         proxy=proxy,
-    ) as sb:
+    )
+    sb = sb_ctx.__enter__()
+    try:
         yield sb
+    finally:
+        sb_ctx.__exit__(None, None, None)
+
 
 
 def save_screenshot(sb: BaseCase):


### PR DESCRIPTION
As mentioned in #192, #189 and #187, Byparr leaves zombie processes after each run, which accumulate over time into the thousands, leaking resources over time. The suggested fix of adjusting or setting `shm_size` did not fix the issue. This PR attempts to salvage the situation.

Here's what I've done to remedy the zombie processes:
- Added [`tini`](https://github.com/krallin/tini) as a dependency and entry point for the docker image.
- Updated the `get_sb` function in `src/utils.py` to handle the SeleniumBase context lifecycle properly.

So far I've had this running for a good hour with no issues or zombie processes. Feel free to validate and test for yourself.