### PR TITLE
renovate - Only test

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip review for Renovate PRs
+    if: github.event.pull_request.user.login != 'renovate[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -143,8 +143,6 @@ jobs:
 
   merge-and-push:
     needs: build
-    # Skip merge-and-push for Renovate PRs
-    if: github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,8 @@ jobs:
 
   build:
     needs: test
+    # Skip build for Renovate PRs
+    if: github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -141,6 +143,8 @@ jobs:
 
   merge-and-push:
     needs: build
+    # Skip merge-and-push for Renovate PRs
+    if: github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Modified CI workflows to optimize Renovate PRs:
- Skip Docker build and merge-and-push jobs for Renovate PRs
- Skip Claude code review for Renovate PRs
- Tests still run for all PRs including Renovate

This reduces CI time and resource usage for dependency update PRs.