### PR TITLE
fix: add tini as init system to reap zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV GITHUB_BUILD=${GITHUB_BUILD}\
     HOME=/tmp
 
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends curl ca-certificates &&\
+    apt-get install -y --no-install-recommends curl ca-certificates tini &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -58,4 +58,4 @@ FROM app
 USER 1000
 EXPOSE $PORT
 HEALTHCHECK --interval=15m --timeout=30s --start-period=5s --retries=3 CMD curl "http://localhost:${PORT}/health"
-ENTRYPOINT ["/app/.venv/bin/python", "main.py"]
+ENTRYPOINT ["tini", "--", "/app/.venv/bin/python", "main.py"]


### PR DESCRIPTION
## Summary
- Installs `tini` in the Docker image and uses it as the entrypoint
- Fixes zombie/defunct Camoufox/Firefox child processes accumulating over time

## Context
Python as PID 1 doesn't reap orphaned child processes. This was reported in #241 and the workaround was `init: true` in compose, but users running `docker run` directly still hit it. Adding tini to the image fixes it for everyone.