### PR TITLE
fix: pin base image to ubuntu:24.04 (ubuntu:latest=26.04 breaks playwright firefox deps)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Ubuntu is required by playwright
-FROM ubuntu:latest AS base
+# Ubuntu is required by playwright.
+# Pin to 24.04 LTS: ubuntu:latest floats to 26.04, which Playwright 1.58
+# cannot install firefox deps for (no libgtk-3 -> camoufox fails to launch).
+FROM ubuntu:24.04 AS base
 
 ARG GITHUB_BUILD=false \
     VERSION


### PR DESCRIPTION
## Problem

`Dockerfile` uses `FROM ubuntu:latest`, which has rolled forward to **Ubuntu 26.04 ("Resolute Raccoon")**. Playwright 1.58 does not support 26.04, so the `app` stage's `playwright install-deps firefox` fails:

```
BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu26.04-x64 as a fallback.
Cannot install dependencies for ubuntu26.04-x64 with Playwright 1.58.0!
```

Because `install-deps` is best-effort, the build still succeeds but the firefox/GTK runtime libraries (`libgtk-3.so.0`, etc.) are never installed. camoufox then fails to launch on **every** request:

```
libgtk-3.so.0: cannot open shared object file: No such file or directory
Couldn't load XPCOM.
```

Symptoms in the wild:
- Every `POST /v1` returns **500**, while `GET /health` still reports **healthy** — so the breakage is silent.
- The orphaned playwright `run-driver` processes from each failed launch accumulate, leaking memory over time (multi-GB on long-running hosts).

This affects anyone whose `:latest`/`main` image was built after `ubuntu:latest` advanced to 26.04.

## Fix

Pin the base to the latest LTS Playwright supports:

```dockerfile
FROM ubuntu:24.04 AS base
```

## Verification

Rebuilt from this branch:
- `playwright install-deps firefox` completes cleanly (installs `libgtk-3-0t64` et al.)
- `ldconfig -p | grep libgtk-3` → `libgtk-3.so.0 ... => /lib/x86_64-linux-gnu/libgtk-3.so.0`
- camoufox launches; requests reach `page.goto()` instead of dying at browser startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)