### PR TITLE
Handle networkidle timeouts after DOM load

### DIFF
--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -93,14 +93,19 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
             status = HTTPStatus.OK
             logger.debug("Challenge solved successfully.")
         else:
-            await dep.page.wait_for_load_state(
-                "networkidle", timeout=timer.remaining() * 1000
-            )
+            try:
+                await dep.page.wait_for_load_state(
+                    "networkidle", timeout=timer.remaining() * 1000
+                )
+            except PlaywrightTimeoutError:
+                logger.warning(
+                    "Timed out waiting for networkidle after domcontentloaded; continuing"
+                )
     except (TimeoutError, PlaywrightTimeoutError) as e:
-        logger.error("Timed out while solving the challenge")
+        logger.error("Timed out while loading the page or solving the challenge")
         raise HTTPException(
             status_code=408,
-            detail="Timed out while solving the challenge",
+            detail="Timed out while loading the page or solving the challenge",
         ) from e
 
     cookies = await dep.context.cookies()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,14 +1,20 @@
 from http import HTTPStatus
 from json import JSONDecodeError
+from types import SimpleNamespace
 
 import httpx
 import pytest
+from fastapi import HTTPException
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from starlette.testclient import TestClient
 
 from main import app
+from src.endpoints import read_item
 from src.models import LinkRequest
+from src.utils import BrowserDepClass
 
 client = TestClient(app)
+PLAYWRIGHT_TIMEOUT_MESSAGE = "timeout"
 
 test_websites = [
     "https://ext.to/",
@@ -62,6 +68,78 @@ def test_health_check():
     """
     response = client.get("/health")
     assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_networkidle_timeout_after_domcontentloaded_returns_content():
+    """Do not fail pages that keep background requests open after DOM load."""
+
+    class Page:
+        url = "https://example.test/login"
+
+        async def goto(self, _url: str, **_kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                status=HTTPStatus.OK, headers={"content-type": "text/html"}
+            )
+
+        async def wait_for_load_state(
+            self, state: str, **_kwargs: object
+        ) -> None:
+            if state == "networkidle":
+                raise PlaywrightTimeoutError(PLAYWRIGHT_TIMEOUT_MESSAGE)
+
+        async def title(self) -> str:
+            return "Login"
+
+        async def evaluate(self, _expression: str) -> str:
+            return "UnitTestBrowser/1.0"
+
+        async def content(self) -> str:
+            return "<html><title>Login</title></html>"
+
+    class Context:
+        async def cookies(self) -> list[object]:
+            return []
+
+    response = await read_item(
+        LinkRequest(url="https://example.test/login"),
+        BrowserDepClass(
+            page=Page(),
+            solver=SimpleNamespace(),
+            context=Context(),
+        ),
+    )
+
+    assert response.status == "ok"
+    assert response.solution.status == HTTPStatus.OK
+    assert response.solution.response == "<html><title>Login</title></html>"
+
+
+@pytest.mark.asyncio
+async def test_domcontentloaded_timeout_returns_408():
+    """Fatal Playwright timeouts still return a controlled HTTP error."""
+
+    class Page:
+        async def goto(self, _url: str, **_kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(status=HTTPStatus.OK, headers={})
+
+        async def wait_for_load_state(
+            self, state: str = "", **_kwargs: object
+        ) -> None:
+            message = f"{state} {PLAYWRIGHT_TIMEOUT_MESSAGE}"
+            raise PlaywrightTimeoutError(message)
+
+    with pytest.raises(HTTPException) as exc:
+        await read_item(
+            LinkRequest(url="https://example.test/login"),
+            BrowserDepClass(
+                page=Page(),
+                solver=SimpleNamespace(),
+                context=SimpleNamespace(),
+            ),
+        )
+
+    assert exc.value.status_code == HTTPStatus.REQUEST_TIMEOUT
 
 
 def test_pdf_handling():


### PR DESCRIPTION
## Summary

- replaces #364 after upstream `main` was rewritten and the original PR could not be reopened
- continue after a non-challenge `networkidle` wait times out once `domcontentloaded` has completed
- still return a controlled 408 for fatal Playwright timeouts during initial page load or challenge solving
- add focused async unit coverage for both timeout paths

## Notes

The Docker base-image pin from #364 is already present on current `main`, so this rebased PR no longer carries that Dockerfile change.

## Validation

- `git diff --check upstream/main..HEAD`
- `uv run --group test pytest tests/main_test.py::test_networkidle_timeout_after_domcontentloaded_returns_content tests/main_test.py::test_domcontentloaded_timeout_returns_408`