### PR TITLE
Install invisible-playwright from PyPI rather than by git URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "API for getting cookies for Cloudflare challenges"
 readme = "README.md"
 dependencies = [
     "fastapi[standard]==0.139.*",
-    "invisible_playwright @ git+https://github.com/feder-cr/invisible_playwright.git",
+    "invisible-playwright>=0.4.9",
     "playwright==1.60.*",
     "playwright-captcha==0.1.*",
     "pydantic==2.*",


### PR DESCRIPTION
Byparr pins invisible_playwright by git URL with no ref, so a resolve picks up whatever main was that day and the lockfile then holds it there. That worked until the engine releases it points at were retired: someone came to us this week with a 404 on a firefox-13 download that arrived through Byparr, and there is nothing we can publish that reaches an install already frozen on an old commit.

The package has been on PyPI since July, and the release pins its own engine, so `invisible-playwright>=0.4.8` gets the browser download and the version bookkeeping together.

Draft because the lockfile needs regenerating on your side and I did not want to guess your uv workflow.