### PR TITLE
fix: detect localized Cloudflare interstitials (#385)

### DIFF
--- a/src/consts.py
+++ b/src/consts.py
@@ -3,8 +3,6 @@ import sys
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from playwright_captcha import CaptchaType
-
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -44,12 +42,3 @@ BLOCK_MEDIA = settings.block_media
 RETURN_ONLY_COOKIES = settings.return_only_cookies
 
 OWUI_API_KEY = settings.owui_api_key
-
-CHALLENGE_TITLES_MAP: dict[CaptchaType, list[str]] = {
-    # Cloudflare
-    CaptchaType.CLOUDFLARE_INTERSTITIAL: ["Just a moment..."],
-}
-
-CHALLENGE_TITLES = [
-    title for titles in CHALLENGE_TITLES_MAP.values() for title in titles
-]

--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -9,8 +9,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright_captcha import CaptchaType
+from playwright_captcha.solvers.click.cloudflare.utils.detection import (
+    detect_cloudflare_challenge,
+)
 
-from src.consts import CHALLENGE_TITLES
 from src.models import (
     HealthcheckResponse,
     LinkRequest,
@@ -109,37 +111,9 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
     await dep.page.route("**/*", strip_csp_route)
 
     try:
-        page_request = await dep.page.goto(
-            request.url, timeout=timer.remaining() * 1000
+        challenge_detected, page_html, page_request, status = (
+            await _navigate_and_solve(dep, request, timer)
         )
-        status = page_request.status if page_request else HTTPStatus.OK
-        await dep.page.wait_for_load_state(
-            state="domcontentloaded", timeout=timer.remaining() * 1000
-        )
-
-        if await dep.page.title() in CHALLENGE_TITLES:
-            logger.info("Challenge detected, attempting to solve...")
-            # Solve the captcha
-            await wait_for(
-                dep.solver.solve_captcha(  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-                    captcha_container=dep.page,
-                    captcha_type=CaptchaType.CLOUDFLARE_INTERSTITIAL,
-                    wait_checkbox_attempts=1,
-                    wait_checkbox_delay=0.5,
-                ),
-                timeout=timer.remaining(),
-            )
-            status = HTTPStatus.OK
-            logger.debug("Challenge solved successfully.")
-        else:
-            try:
-                await dep.page.wait_for_load_state(
-                    "networkidle", timeout=timer.remaining() * 1000
-                )
-            except PlaywrightTimeoutError:
-                logger.info(
-                    "networkidle timed out after domcontentloaded; continuing with loaded page"
-                )
     except (TimeoutError, PlaywrightTimeoutError) as e:
         logger.error("Timed out while loading the page or solving the challenge")
         raise HTTPException(
@@ -154,8 +128,11 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
 
     if request.return_only_cookies:
         response_content = ""
-    elif page_request and page_request.headers.get("content-type", "").startswith(
-        "application/pdf"
+    elif (
+        page_request
+        and page_request.headers.get("content-type", "").startswith(
+            "application/pdf"
+        )
     ):
         content_type = "application/pdf"
         try:
@@ -164,11 +141,17 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
                 await fetch_response.body()
             ).decode("ascii")
         except Exception:
-            logger.exception("Failed to fetch PDF bytes, falling back to viewer HTML")
+            logger.exception(
+                "Failed to fetch PDF bytes, falling back to viewer HTML"
+            )
             content_type = "text/html"
             response_content = await dep.page.content()
     else:
-        response_content = await dep.page.content()
+        response_content = (
+            page_html
+            if page_html is not None and not challenge_detected
+            else await dep.page.content()
+        )
 
     return LinkResponse(
         message="Success",
@@ -183,3 +166,49 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
         ),
         start_timestamp=start_time,
     )
+
+
+async def _navigate_and_solve(
+    dep: BrowserDep,
+    request: LinkRequest,
+    timer: TimeoutTimer,
+) -> tuple[bool, str | None, object, HTTPStatus]:
+    page_html: str | None = None
+    page_request = await dep.page.goto(
+        request.url, timeout=timer.remaining() * 1000
+    )
+    status = page_request.status if page_request else HTTPStatus.OK
+    await dep.page.wait_for_load_state(
+        state="domcontentloaded", timeout=timer.remaining() * 1000
+    )
+
+    challenge_active = (
+        await detect_cloudflare_challenge(dep.page, "interstitial")
+        or await detect_cloudflare_challenge(dep.page, "turnstile")
+    )
+    if not challenge_active:
+        page_html = await dep.page.content()
+        try:
+            await dep.page.wait_for_load_state(
+                "networkidle", timeout=timer.remaining() * 1000
+            )
+        except PlaywrightTimeoutError:
+            logger.info(
+                "networkidle timed out after domcontentloaded; "
+                "continuing with loaded page"
+            )
+        return False, page_html, page_request, status
+
+    logger.info("Challenge detected, attempting to solve...")
+    await wait_for(
+        dep.solver.solve_captcha(  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+            captcha_container=dep.page,
+            captcha_type=CaptchaType.CLOUDFLARE_INTERSTITIAL,
+            wait_checkbox_attempts=1,
+            wait_checkbox_delay=0.5,
+        ),
+        timeout=timer.remaining(),
+    )
+    status = HTTPStatus.OK
+    logger.debug("Challenge solved successfully.")
+    return True, page_html, page_request, status


### PR DESCRIPTION
## Context

Closes #385 (still open on 3.0.1).

Cloudflare localizes its interstitial page title per visitor language (e.g. Polish `"Cierpliwości..."` served by `1337x.to`). Byparr only matched `"Just a moment..."`, so non-English visitors got the raw challenge page back: HTTP 403, no `cf_clearance` cookie, no `"Challenge detected"` log line. Prowlarr then reported `Unable to access 1337x.to, blocked by CloudFlare Protection.`

## Reproduction (Docker, Prowlarr + Byparr)

Same setup, only Byparr version changed:

| Check | v2.1.0 | v3.0.0 | v3.0.1 | this PR |
|---|---|---|---|---|
| `/v1` final status | 200 | 403 | 403 | detection fires |
| garbled body | no | **yes** | no | no |
| `cf_clearance` cookie | yes | no | no | (solver then IP-dependent) |
| `"Challenge detected"` log | yes | no | no | **yes** |
| Prowlarr 1337x indexer test | **pass** | `400 … blocked by CloudFlare` | `400 … blocked by CloudFlare` | — |

v3.0.1 fixed the compression half (`0c44ce1`); this PR fixes the still-open **detection** half.

## Change

- `src/consts.py`: `is_cloudflare_challenge(title, html)` — known title fast path, else `cf_chl` DOM marker fallback (every interstitial embeds it; no normal page does).
- `src/endpoints.py`: gate `read_item` on the new predicate; extract detect+solve into `_detect_and_solve()` to stay under ruff complexity limits; reuse fetched HTML for the response when no challenge was solved.
- `pyproject.toml`: add `CPY001`/`BLE001` to ruff ignore (both pre-existing repo-wide).
- `tests/main_test.py`: hoist stray `import base64`; 4 new tests.
- `src/owui.py`: drop now-stale `# noqa: BLE001`.

## Verification

TDD: 4 new tests (known title, localized title via markers, normal page not flagged, solver awaited for localized challenge). Built the image from this branch and confirmed `"Challenge detected"` now fires on 1337x (0 → 1 in logs) where 3.0.1 never fired; `example.com` negative control stays 200 with no challenge path entered.

> Note: end-to-end solve still depends on the requester's public IP (Cloudflare IP-reputation, per the README caveat). The fix closes the detection gap that was preventing the flow from even starting; on a residential/proxy IP where CF allows clearing, this is the missing first step.