### PR TITLE
feat: add BROWSER_LOCALE env to override browser language

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@
 | `PROXY_USERNAME`     | None      | Username for proxy authentication.                                                                                                                                |
 | `PROXY_PASSWORD`     | None      | Password for proxy authentication.                                                                                                                                |
 | `OWUI_API_KEY`       | None      | Bearer token for `/load` endpoint authentication. Must match `EXTERNAL_WEB_LOADER_API_KEY` in Open WebUI.                                                         |
+| `BROWSER_LOCALE`     | None      | Override the browser's language with a [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) tag, e.g. `en-US`, `de-DE`, `fr-FR`. When unset, the locale is derived from the egress country. |
+
+#### Browser language
+
+Set `BROWSER_LOCALE` to a [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag like `en-US`, `de-DE`, `fr-FR`, `pl-PL`, or `zh-CN` to fix the browser's language and `Accept-Language` header. When unset, Byparr derives the locale from the egress country (e.g. a French proxy → `fr-FR`), keeping the browser language consistent with the exit IP.
+
+Valid tags are maintained in the [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry). For a friendlier list, see [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (language) combined with an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) region code for the full tag, e.g. `pt-BR`.
 
 ## Proxy Recommendation
 

--- a/src/consts.py
+++ b/src/consts.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     block_media: bool = False
     return_only_cookies: bool = False
     owui_api_key: str | None = None
+    browser_locale: str | None = None
 
 
 settings = Settings()
@@ -44,6 +45,8 @@ BLOCK_MEDIA = settings.block_media
 RETURN_ONLY_COOKIES = settings.return_only_cookies
 
 OWUI_API_KEY = settings.owui_api_key
+
+BROWSER_LOCALE = settings.browser_locale
 
 CHALLENGE_TITLES_MAP: dict[CaptchaType, list[str]] = {
     # Cloudflare

--- a/src/utils.py
+++ b/src/utils.py
@@ -13,6 +13,7 @@ from playwright_captcha import (
 from pydantic import BaseModel, Field
 
 from src.consts import (
+    BROWSER_LOCALE,
     LOG_LEVEL,
     MAX_ATTEMPTS,
     PROXY_PASSWORD,
@@ -94,7 +95,7 @@ async def get_browser(
         headless=True,
         proxy=proxy_config,
         humanize=True,
-        locale="auto",
+        locale=BROWSER_LOCALE or "auto",
     ) as browser_raw:
         # InvisiblePlaywright yields a Browser instance
         browser = cast("Browser", browser_raw)


### PR DESCRIPTION
## What

Adds an optional `BROWSER_LOCALE` environment variable that overrides the browser's language. Currently the browser locale is hardcoded to `"auto"`, which derives the language from the egress country (proxy IP). Setting `BROWSER_LOCALE` to a BCP-47 tag (e.g. `en-US`, `de-DE`) now fixes the browser language and `Accept-Language` header instead.

## Why `BROWSER_LOCALE` and not `LANG`

`LANG` is a standard OS environment variable on Linux (`en_US.UTF-8`, `C.UTF-8`, `POSIX`), set on virtually every host and in many container images. Using it directly would pass malformed BCP-47 tags into the browser context and silently break the `auto` behavior. `BROWSER_LOCALE` is only set deliberately, so values pass through verbatim.

## Changes

- `src/consts.py`: `browser_locale: str | None = None` setting (auto-mapped from `BROWSER_LOCALE`), exported as `BROWSER_LOCALE`.
- `src/utils.py`: `locale=BROWSER_LOCALE or "auto"` in the `InvisiblePlaywright` launch — unset behaves exactly as before.
- `README.md`: options table row + "Browser language" section with links to the IANA Language Subtag Registry and ISO 639-1/3166-1 lists for valid tag values.

## Verification

- `BROWSER_LOCALE=pl-PL` → `BROWSER_LOCALE == "pl-PL"` in settings.
- Unset → `None` → falls back to `"auto"`.
- `ruff check` on changed files: only pre-existing errors on HEAD (unrelated import order / missing copyright).