### PR TITLE
fix: /v1 must survive CSP-blocked evaluate (incl. Firefox JSON viewer)

### DIFF
--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -153,10 +153,25 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
             else await dep.page.content()
         )
 
+    # The User-Agent the target site actually saw, taken from the navigation
+    # request headers. page.evaluate falls through to eval() in the page's
+    # main world and fails whenever the page CSP disallows eval (e.g. the
+    # Firefox JSON viewer in #394, or uncatchable meta-tag CSP), so evaluate
+    # is only a fallback and its failure must not turn the request into a 500.
+    user_agent = (
+        page_request.request.headers.get("user-agent") if page_request else None
+    )
+    if user_agent is None:
+        try:
+            user_agent = await dep.page.evaluate("navigator.userAgent")
+        except Exception:
+            logger.warning("Could not determine User-Agent via page.evaluate")
+            user_agent = ""
+
     return LinkResponse(
         message="Success",
         solution=Solution(
-            user_agent=await dep.page.evaluate("navigator.userAgent"),
+            user_agent=user_agent,
             url=final_url if final_url is not None else dep.page.url,
             status=status,
             cookies=cookies,

--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -153,11 +153,6 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
             else await dep.page.content()
         )
 
-    # The User-Agent the target site actually saw, taken from the navigation
-    # request headers. page.evaluate falls through to eval() in the page's
-    # main world and fails whenever the page CSP disallows eval (e.g. the
-    # Firefox JSON viewer in #394, or uncatchable meta-tag CSP), so evaluate
-    # is only a fallback and its failure must not turn the request into a 500.
     user_agent = (
         page_request.request.headers.get("user-agent") if page_request else None
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -96,6 +96,12 @@ async def get_browser(
         proxy=proxy_config,
         humanize=True,
         locale=BROWSER_LOCALE or "auto",
+        # Firefox renders application/json documents in a built-in viewer whose
+        # own CSP (`script-src resource:`) blocks Playwright's eval-based
+        # evaluate(), crashing /v1 on JSON APIs (issue #394). Disabling the
+        # viewer renders JSON as plain text: evaluate works and consumers get
+        # the raw JSON instead of the viewer's HTML markup.
+        extra_prefs={"devtools.jsonview.enabled": False},
     ) as browser_raw:
         # InvisiblePlaywright yields a Browser instance
         browser = cast("Browser", browser_raw)

--- a/src/utils.py
+++ b/src/utils.py
@@ -96,11 +96,6 @@ async def get_browser(
         proxy=proxy_config,
         humanize=True,
         locale=BROWSER_LOCALE or "auto",
-        # Firefox renders application/json documents in a built-in viewer whose
-        # own CSP (`script-src resource:`) blocks Playwright's eval-based
-        # evaluate(), crashing /v1 on JSON APIs (issue #394). Disabling the
-        # viewer renders JSON as plain text: evaluate works and consumers get
-        # the raw JSON instead of the viewer's HTML markup.
         extra_prefs={"devtools.jsonview.enabled": False},
     ) as browser_raw:
         # InvisiblePlaywright yields a Browser instance

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -58,6 +58,34 @@ def test_bypass(website: str):
     assert response.status_code == HTTPStatus.OK
 
 
+def test_json_api():
+    """JSON APIs must return 200, not crash on the UA evaluate.
+
+    Firefox renders application/json in a built-in viewer whose CSP blocks
+    Playwright's eval-based evaluate() (issue #394). The browser must be
+    launched with the viewer disabled so /v1 works and returns the raw JSON.
+    """
+    url = "https://api.ipify.org?format=json"
+    test_request = httpx2.get(url)
+    if test_request.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        pytest.skip(
+            f"Skipping JSON API test - upstream error ({test_request.status_code})"
+        )
+
+    response = client.post(
+        "/v1",
+        json=LinkRequest.model_construct(url=url, cmd="request.get").model_dump(),
+    )
+
+    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+        pytest.skip("Skipping JSON API test - timed out (upstream issue)")
+
+    assert response.status_code == HTTPStatus.OK
+    solution = response.json()["solution"]
+    assert solution["user_agent"]
+    assert '"ip"' in solution["response"]
+
+
 def test_health_check():
     """
     Tests the health check endpoint.

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -139,7 +139,9 @@ def fake_dep(*, fail_states: set[str] | None = None) -> BrowserDepClass:
     page = AsyncMock()
     page.url = "https://example.test/login"
     page.goto.return_value = MagicMock(
-        status=HTTPStatus.OK, headers={"content-type": "text/html"}
+        status=HTTPStatus.OK,
+        headers={"content-type": "text/html"},
+        request=MagicMock(headers={"user-agent": "UnitTestBrowser/1.0"}),
     )
     page.title.return_value = "Login"
     page.evaluate.return_value = "UnitTestBrowser/1.0"
@@ -181,3 +183,22 @@ async def test_domcontentloaded_timeout_returns_408():
         )
 
     assert exc.value.status_code == HTTPStatus.REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_user_agent_survives_csp_blocked_evaluate():
+    """UA comes from request headers when page CSP blocks evaluate (#394).
+
+    No CSP configuration (header, meta tag, or internal viewer document) may
+    turn /v1 into a 500.
+    """
+    dep = fake_dep()
+    dep.page.evaluate.side_effect = Exception("call to eval() blocked by CSP")
+
+    response = await read_item(
+        LinkRequest(url="https://example.test/login"),
+        dep,
+    )
+
+    assert response.status == "ok"
+    assert response.solution.user_agent == "UnitTestBrowser/1.0"

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -83,7 +83,7 @@ def test_json_api():
 
     assert response.status_code == HTTPStatus.OK
     solution = response.json()["solution"]
-    assert solution["user_agent"]
+    assert solution["userAgent"]
     assert '"ip"' in solution["response"]
 
 


### PR DESCRIPTION
## What

`/v1` 500s whenever the loaded page's CSP disallows `eval()` — Playwright's `page.evaluate` runs `eval()` in the page's main world, so **any** CSP cause can crash the response path ("closes #394" via one such cause).

## Root causes covered

1. **Firefox JSON viewer** (#394): `application/json` documents render in a built-in viewer whose own `<meta>` CSP (`script-src resource:`) blocks eval. No response header is involved, so the existing header-stripping route could never catch it. This is why the previous CSP fixes looked complete but weren't.
2. **General CSP independence**: even non-viewer pages can block eval — most notably CSP delivered via `<meta http-equiv="Content-Security-Policy">`, which the header-strip route cannot remove. The only durable guarantee is to stop *requiring* main-world eval for the response.

## Fix

- `src/utils.py`: launches with `extra_prefs={"devtools.jsonview.enabled": False}`. JSON renders as plain text → evaluate works again *and* API consumers get the raw JSON body instead of the viewer's syntax-highlighted HTML.
- `src/endpoints.py`: `user_agent` comes from the navigation **request headers** (what the site actually saw); `page.evaluate("navigator.userAgent")` is kept only as a best-effort fallback whose failure logs a warning instead of 500ing. This makes the endpoint immune to the whole "eval blocked by CSP" class, whatever the cause.
- `owui.py` needed no change: `/load` already degrades to empty content on any extraction failure.

(Explicitly *not* added: stripping `<meta http-equiv="Content-Security-Policy">` from fulfilled HTML bodies. Feasible, but Cloudflare-style pages can use a CSP-blocked canary script to detect tampering — with the fallback above, we no longer need to touch page CSP at all.)

## Test

- `tests/main_test.py` (`test_json_api`): exact #394 scenario — POST `/v1` with `https://api.ipify.org?format=json` → 200, UA present, raw JSON in body.
- New mock test (`test_user_agent_survives_csp_blocked_evaluate`): page.evaluate raises the exact CSP error; endpoint still returns 200 with UA from request headers — this is the future-proofing regression for the whole class.

## Verification

- Local: 9/9 mock/unit tests pass.
- Docker container with both commits applied:
  - `POST /v1` → `api.ipify.org?format=json` → **200**, UA populated, raw JSON body (was 500)
  - `POST /v1` → `example.com` → 200, `GET /health` → 200
  - Confirmed without the pref, viewer-on: `evaluate` fails on ipify and `api.github.com`; `text/plain` and `text/html` fine.