### PR TITLE
fix: TLS Handshake doesn't match a normal browser

### DIFF
--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -72,6 +72,12 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
     timer = TimeoutTimer(duration=request.max_timeout)
     request.url = request.url.replace('"', "").strip()
 
+    try:
+        user_agent = await dep.page.evaluate("navigator.userAgent")
+    except Exception:
+        logger.warning("Could not determine User-Agent via page.evaluate")
+        user_agent = None
+
     final_url = await setup_routes(request, dep)
 
     try:
@@ -92,15 +98,8 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
         page_html=page_html,
     )
 
-    user_agent = (
-        page_request.request.headers.get("user-agent") if page_request else None
-    )
     if user_agent is None:
-        try:
-            user_agent = await dep.page.evaluate("navigator.userAgent")
-        except Exception:
-            logger.warning("Could not determine User-Agent via page.evaluate")
-            user_agent = ""
+        user_agent = page_request.request.headers.get("user-agent") if page_request else ""
 
     return LinkResponse(
         message="Success",

--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -28,18 +28,6 @@ router = APIRouter()
 
 BrowserDep = Annotated[BrowserDepClass, Depends(get_browser)]
 
-# Headers to strip from the fulfilled response: CSP is removed for navigation
-# freedom, and content-encoding/content-length are stale once we request an
-# uncompressed body via accept-encoding: identity below.
-DROP_HEADERS = frozenset(
-    {
-        "content-security-policy",
-        "content-security-policy-report-only",
-        "content-encoding",
-        "content-length",
-    }
-)
-
 
 @router.get("/", include_in_schema=False)
 def read_root():
@@ -78,7 +66,7 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
         logger.warning("Could not determine User-Agent via page.evaluate")
         user_agent = None
 
-    final_url = await setup_routes(request, dep)
+    await setup_routes(request, dep)
 
     try:
         challenge_detected, page_html, page_request, status = (
@@ -105,7 +93,7 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
         message="Success",
         solution=Solution(
             user_agent=user_agent,
-            url=final_url if final_url is not None else dep.page.url,
+            url=dep.page.url,
             status=status,
             cookies=cookies,
             headers=page_request.headers if page_request else {},
@@ -116,12 +104,9 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
     )
 
 
-async def setup_routes(request: LinkRequest, dep: BrowserDep) -> str | None:
+async def setup_routes(request: LinkRequest, dep: BrowserDep) -> None:
     """
-    Install request routes for media blocking and CSP stripping.
-
-    Returns the final URL captured during navigation; callers read it after
-    the page settles.
+    Install request routes for media blocking.
     """
     if request.block_media:
 
@@ -132,34 +117,6 @@ async def setup_routes(request: LinkRequest, dep: BrowserDep) -> str | None:
                 await route.continue_()
 
         await dep.page.route("**/*", block_media_route)
-
-    final_url: str | None = None
-
-    async def strip_csp_route(route) -> None:
-        nonlocal final_url
-        if route.request.resource_type != "document":
-            await route.continue_()
-            return
-        # Request an uncompressed body via accept-encoding: identity. When
-        # route.fulfill re-serves the fetched response (by uid), it forwards
-        # the original compressed bytes; stripping content-encoding below
-        # would leave the browser reading compressed bytes as plain text.
-        response = await route.fetch(
-            headers={**route.request.headers, "accept-encoding": "identity"}
-        )
-        if route.request.frame == dep.page.main_frame:
-            final_url = response.url
-        await route.fulfill(
-            response=response,
-            headers={
-                key: value
-                for key, value in response.headers.items()
-                if key.lower() not in DROP_HEADERS
-            },
-        )
-
-    await dep.page.route("**/*", strip_csp_route)
-    return final_url
 
 
 async def _navigate_and_solve(

--- a/src/owui.py
+++ b/src/owui.py
@@ -43,7 +43,7 @@ async def _extract_content(page: Page) -> str:
     article = trafilatura.extract(await page.content())
     if article:
         return article
-    result = await page.evaluate("() => document.body ? document.body.innerText : ''")
+    result = await page.locator("body").inner_text()
     return "\n".join(line.strip() for line in result.splitlines() if line.strip())
 
 

--- a/tests/owui_test.py
+++ b/tests/owui_test.py
@@ -78,7 +78,8 @@ def fake_dep(*, html: str = ARTICLE_HTML) -> BrowserDepClass:
     page = AsyncMock()
     page.goto.return_value = MagicMock()
     page.content.return_value = html
-    page.evaluate.return_value = "line one\n\nline two"
+    page.locator = MagicMock()
+    page.locator.return_value.inner_text = AsyncMock(return_value="line one\n\nline two")
 
     def wait_for_load_state(state: str, **_kwargs: object) -> None:
         if state == "networkidle":


### PR DESCRIPTION
This PR fixes #398 by resolving the issues between `evaluate` and CSPs in order to remove `route.fetch` which is the root cause of the issue, instead of removing the CSP headers so `evaluate` works (https://github.com/ThePhaseless/Byparr/commit/6d447a0d67f12b0fb23bf779bdd3265780d3c0a5) I've taken a different approach which is to leave CSP alone and instead avoid `evaluate` where possible and only running it where CSPs are not present.

First in `owui.py` I replaced `page.evaluate("() => document.body ? document.body.innerText : ''")` with `page.locator("body").inner_text()`, this replicates the previous logic while avoiding `evaluate` and its CSP issues.

Second in `endpoints.py` I moved `page.evaluate("navigator.userAgent")` to happen **BEFORE** any navigation, this allows `evaluate` to run without having to worry about any CSPs that maybe present in the response headers or the document itself. The `page_request.request.headers.get("user-agent")` is still present as a fallback.

Finally I removed all the manual CSP handling as it's no longer required, additionally the `Accept-Encoding: identity` header was adding another discrepancy to the request which should be avoided in future.

Disclaimer: I'm not a python developer so this PR should be extensively looked over and tested to ensure no regressions have been introduced.