### PR TITLE
fix: abort route when fetch fails so navigation doesn't hang

### DIFF
--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -145,9 +145,19 @@ async def setup_routes(request: LinkRequest, dep: BrowserDep) -> str | None:
         # route.fulfill re-serves the fetched response (by uid), it forwards
         # the original compressed bytes; stripping content-encoding below
         # would leave the browser reading compressed bytes as plain text.
-        response = await route.fetch(
-            headers={**route.request.headers, "accept-encoding": "identity"}
-        )
+        #
+        # #402: if route.fetch raises (unreachable host, DNS failure), the
+        # exception escapes into Playwright's event-listener error handler
+        # — the route is never fulfilled nor continued, so the browser's
+        # navigation stalls for the full maxTimeout budget. Abort instead
+        # so page.goto surfaces the failure in milliseconds.
+        try:
+            response = await route.fetch(
+                headers={**route.request.headers, "accept-encoding": "identity"}
+            )
+        except Exception:
+            await route.abort()
+            return
         if route.request.frame == dep.page.main_frame:
             final_url = response.url
         await route.fulfill(


### PR DESCRIPTION
Fixes #402.

When route.fetch() raises (unreachable host, DNS failure), the exception escapes into Playwright's event-listener error handler — the route is never fulfilled nor continued, so the browser's navigation stalls permanently and page.goto() burns its entire maxTimeout budget.

The fix wraps route.fetch in a try/except and calls route.abort() on error, so the failure surfaces in milliseconds instead of after the full timeout. Evidence from the issue: 690 occurrences of the unhandled event-listener error in the sample window.