### PR TITLE
fix: scope returned cookies to the requested page

### DIFF
--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -82,7 +82,15 @@ async def read_item(request: LinkRequest, dep: BrowserDep) -> LinkResponse:
             detail=f"Could not reach the target: {e}",
         ) from e
 
-    cookies = await dep.context.cookies()
+    # Scope the cookies to the page that was asked for. An unscoped call returns every
+    # cookie in the browser context, including ones set by third-party frames and ads,
+    # and a single malformed third-party value makes a client discard the whole jar,
+    # cf_clearance with it. Selenium, which FlareSolverr uses, only ever returned the
+    # cookies for the current document, so clients are built for the scoped shape.
+    cookie_urls = [request.url]
+    if dep.page.url and dep.page.url not in cookie_urls:
+        cookie_urls.append(dep.page.url)
+    cookies = await dep.context.cookies(cookie_urls)
     content_type, response_content = await build_response_content(
         dep.page,
         request,


### PR DESCRIPTION
Fixes #408. @Jellman86 traced this one and suggested the change; I hit the same thing on my own setup and measured it.

`context.cookies()` with no argument returns every cookie in the browser context, not just the ones for the page that was asked for. A single malformed third-party value then makes the client throw away the whole jar, `cf_clearance` included, so the solve succeeds and the client still reports the site as blocked.

Measured against `https://kickass.ws/new/?field=time_add&sorder=desc` on my own Byparr, before and after, same container:

| | before | after |
| --- | --- | --- |
| cookies returned | 171 | 14 |
| domains | 46 | 2 (`kickass.ws`, `.kickass.ws`) |
| values containing a comma | 1 | 0 |
| `cf_clearance` present | yes | yes |

The offending cookie on my run was `RedirectDomains` from `.iqoption.net`, value `iqoption.com,fxclube.com`, which is exactly the shape .NET's `CookieContainer` rejects in the Prowlarr traceback in the issue.

One thing I did beyond the suggestion in the issue: the call also passes the final page URL when a redirect moved it, so a cookie set on the landing host is not dropped. Both URLs go in one list and Playwright dedupes the result.

`ruff check` and `ruff format --check` are clean. I did not add a test, since the existing suite drives a real browser and I had no way to assert cookie scoping without one; happy to add something if you have a pattern in mind.