### PR TITLE
pass log level to uvicorn

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,8 +14,10 @@ from src.middlewares import LogRequest
 from src.owui import router as owui_router
 from src.utils import get_browser, logger
 
+LOG_LEVEL_NAME = logging.getLevelName(LOG_LEVEL).lower()
+
 logger.info("Using version %s", VERSION)
-logger.info("Log level set to %s", logging.getLevelName(LOG_LEVEL))
+logger.info("Log level set to %s", LOG_LEVEL_NAME)
 
 app = FastAPI(debug=LOG_LEVEL == logging.DEBUG, log_level=LOG_LEVEL)
 app.add_middleware(GZipMiddleware)
@@ -40,4 +42,4 @@ if __name__ == "__main__":
         loop.run_until_complete(init())
         logger.info("Initialization complete.")
     else:
-        uvicorn.run(app, host=HOST, port=PORT)
+        uvicorn.run(app, host=HOST, port=PORT, log_level=LOG_LEVEL_NAME)


### PR DESCRIPTION
logger is currently hooking into uvicorn.error https://github.com/ThePhaseless/Byparr/blob/main/src/utils.py#L27 but uvicorn doesn't know that and in run() sets the log level back to INFO.

Repro: none of Byparr's (invisible_playwright is a different logger so it does work) logger.debug calls ever actually show, even when LOG_LEVEL is set to debug

Separately, logger should probably be Dispatcharr's own instance instead of using uvicorn.error.